### PR TITLE
Fix mood diary view name

### DIFF
--- a/lib/introduction_animation/components/mood_diary_view.dart
+++ b/lib/introduction_animation/components/mood_diary_view.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 
-class MoodDiaryVew extends StatelessWidget {
+class MoodDiaryView extends StatelessWidget {
   final AnimationController animationController;
 
-  const MoodDiaryVew({Key? key, required this.animationController})
+  const MoodDiaryView({Key? key, required this.animationController})
     : super(key: key);
 
   @override
@@ -77,7 +77,7 @@ class MoodDiaryVew extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   Text(
-                    "Mood Dairy",
+                    "Mood Diary",
                     style: TextStyle(fontSize: 26.0, fontWeight: FontWeight.bold),
                   ),
                   SlideTransition(

--- a/lib/introduction_animation/introduction_animation_screen.dart
+++ b/lib/introduction_animation/introduction_animation_screen.dart
@@ -5,7 +5,7 @@ import 'components/splash_view.dart';
 import 'components/top_back_skip_view.dart';
 import 'components/welcome_view.dart';
 import 'components/manage_smarter.dart';
-import 'components/mood_diary_vew.dart';
+import 'components/mood_diary_view.dart';
 import 'package:flutter/material.dart';
 
 class IntroductionAnimationScreen extends StatefulWidget {
@@ -73,7 +73,7 @@ class _IntroductionAnimationScreenState
               ManageSmarter(
                 animationController: _animationController!,
               ),
-              MoodDiaryVew(
+              MoodDiaryView(
                 animationController: _animationController!,
               ),
               WelcomeView(


### PR DESCRIPTION
## Summary
- rename `mood_diary_vew.dart` to `mood_diary_view.dart`
- update class to `MoodDiaryView` and fix title text
- reference new view in introduction animation screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840339b5e708329b96a4f5ff366391c